### PR TITLE
purposely break test to see if circleci catches

### DIFF
--- a/tests/parsing/parse-user-test.js
+++ b/tests/parsing/parse-user-test.js
@@ -7,7 +7,7 @@ import parseUser from '../../src/parsing/parse-user';
 
 test('Assertions with tape.', (assert) => {
   const mockData = {
-    "login": "dpastoor",
+    "login": "dpastoor_wrong",
     "id": 3196313,
     "avatar_url": "https://avatars.githubusercontent.com/u/3196313?v=3",
     "gravatar_id": "",


### PR DESCRIPTION
changed name to non-valid outcome
